### PR TITLE
FIX: Mengikat model ke pengkalan data untuk aplikasi pelayan

### DIFF
--- a/samudra/cli/database.py
+++ b/samudra/cli/database.py
@@ -1,19 +1,19 @@
 from pathlib import Path
 
 import typer
-from typer import Typer
 from rich import print
+from typer import Typer
 
-from samudra.models import create_tables
-from samudra.conf.local import save_database, get_databases_config
+from samudra.conf.database.core import get_database, set_active_database
 from samudra.conf.database.options import DatabaseEngine
-from samudra.conf.database.core import get_database
+from samudra.conf.local import read_databases_list
+from samudra.models import create_tables
 
 app = Typer()
 
 
 @app.command()
-def create(
+def new(
     name: str = typer.Argument(..., rich_help_panel="Name of database."),
     path: str = typer.Option(".", rich_help_panel="Path to store database (SQLite)"),
     experimental: bool = typer.Option(
@@ -27,13 +27,12 @@ def create(
     ),
 ) -> None:
     """Creates a new database"""
-    database = get_database(db_name=name, engine=engine, path=path, new=True)
+    database = get_database(name=name, engine=engine, path=path, new=True)
     tables = create_tables(
         database=database,
         auth=False,
         experimental=experimental,
     )
-    save_database(db_name=name, path=Path(path))
     print(
         f"`samudra.db` has been created in {Path(path, name).resolve()} with the following tables:"
     )
@@ -41,7 +40,14 @@ def create(
 
 
 @app.command()
+def set(name: str = typer.Argument(..., rich_help_panel="Name of database")) -> None:
+    """Sets an active database"""
+    set_active_database(name=name)
+    print(f"The active database has been set to `{name}`")
+
+
+@app.command()
 def list():
     """Lists available databases"""
     # TODO Print as tables
-    print(get_databases_config()["databases"])
+    print(read_databases_list()["databases"])

--- a/samudra/cli/golongan_kata.py
+++ b/samudra/cli/golongan_kata.py
@@ -1,7 +1,7 @@
 import typer
 
-from samudra.core import crud
 from samudra.conf.setup import access_database
+from samudra.core import crud
 from samudra.models import bind_to_database
 from samudra.schemas import CreateGolonganKata
 
@@ -19,8 +19,6 @@ def new(
     ),
 ):
     """Creates a new word class."""
-    # TODO Only bind during instantiation
-    bind_to_database(database=access_database(local=True), auth=True, experimental=True)
     crud.create_golongan_kata(
         data=CreateGolonganKata(id=id, nama=nama, keterangan=keterangan)
     )

--- a/samudra/cli/lemma.py
+++ b/samudra/cli/lemma.py
@@ -1,9 +1,9 @@
-from typing import List, Dict
+from typing import List
 
 import typer
 
-from samudra.core import crud
 from samudra.conf.setup import access_database
+from samudra.core import crud
 from samudra.models import bind_to_database
 
 app = typer.Typer()
@@ -31,7 +31,6 @@ def new(
         False, rich_help_panel="Create a new lemma not caring if it already created"
     ),
 ):
-    bind_to_database(database=access_database(local=True), auth=True, experimental=True)
     if concept is None:
         crud.create_lemma(lemma=lemma, force=force)
     crud.create_konsep(

--- a/samudra/conf/database/core.py
+++ b/samudra/conf/database/core.py
@@ -77,9 +77,12 @@ def get_sqlite(folder: str, path: str, db_file: str = "samudra.db", new: bool = 
     # The DB connection object
     # ? Perlu ke test?
     # TODO Add Test
+    base_path: Path = Path(path, folder)
+    full_path: Path = Path(base_path, db_file)
     if new:
-        base_path: Path = Path(path, folder)
-        full_path: Path = Path(base_path, db_file)
+        # If a new database is to be created, check if the given path is occupied.
+        # If not occupied, create the database.
+        # If occupied, raise FileExistsError
         try:
             base_path.mkdir(parents=True)
         except FileExistsError:
@@ -91,7 +94,7 @@ def get_sqlite(folder: str, path: str, db_file: str = "samudra.db", new: bool = 
                 print(f"Populating empty folder `{base_path.resolve()}` with {db_file}")
             else:
                 raise FileExistsError(
-                    f"The path `{base_path.resolve()}` is already occupied with something else. Consider using other folder."
+                    f"The path `{base_path.resolve()}` is already occupied with something else. Try passing `new=False` to access the database or consider creating new database in another folder."
                 )
         # Set up readme
         README = Path(base_path, "README.md")
@@ -103,14 +106,18 @@ def get_sqlite(folder: str, path: str, db_file: str = "samudra.db", new: bool = 
                     "Created using [samudra](https://github.com/samudradev/samudra)",
                 ]
             )
-    else:
-        db_obj = get_database_info(name=db_file)
-        if db_obj is None:
-            return FileNotFoundError(
-                f"The database name {db_file} is not found. Perhaps it is not created yet. Pass the key `new=True` if that's the case"
-            )
-        base_path: Path = Path(db_obj["path"], folder=db_file)
-        full_path: Path = Path(base_path, db_file)
+    # else:
+    #     # Originally, this part was intended to get the path to database via its name in the local `~/.samudra/databases.toml` file when `new=False`.
+    #     # However, that would mean that the `path` parameter is rendered meaningless unless `new=True`.
+    #     # Perhaps this functionality should be outside the function with paths and folder parameters as its result
+    #     # which will be passed to `get_database/get_sqlite` with explicit `new=False`
+    #     db_obj = get_database_info(name=db_file)
+    #     if db_obj is None:
+    #         return FileNotFoundError(
+    #             f"The database name {db_file} is not found. Perhaps it is not created yet. Pass the key `new=True` if that's the case"
+    #         )
+    #     base_path: Path = Path(db_obj["path"], folder=db_file)
+    #     full_path: Path = Path(base_path, db_file)
     return_db = pw.SqliteDatabase(
         full_path.resolve(),
         check_same_thread=False,

--- a/samudra/conf/database/core.py
+++ b/samudra/conf/database/core.py
@@ -1,127 +1,134 @@
-from contextvars import ContextVar
 import logging
 import os
-from dataclasses import dataclass
+from contextvars import ContextVar
 from pathlib import Path
-from unicodedata import name
 
 import peewee as pw
 
-from conf.local import get_database_info
-
-# ! Importing settings will create circular import
-# from conf.setup import settings
+from conf.local import (
+    read_database_info,
+    write_config,
+    read_config,
+    append_database_list,
+)
+from models.base import database_proxy
 from samudra.conf.database.options import DatabaseEngine
-
-# TODO: Enforce requirements per database engine
-
-
-# As settings
-# ENGINE = settings.get("database").get("engine", None)
-# DATABASE_NAME = settings.get("database").get("name", "samudra")
 
 db_state_default = {"closed": None, "conn": None, "ctx": None, "transactions": None}
 db_state = ContextVar("db_state", default=db_state_default.copy())
 
 
-def get_database(db_name: str, engine: DatabaseEngine, **kwargs) -> pw.Database:
-    """
-    Returns the connection class based on the engine.
-    """
-    if engine is None or engine not in DatabaseEngine.__members__.values():
-        raise ValueError(
-            "Please specify database engine in conf.toml. You entered {}. Valid values are: \n - {}".format(
-                engine, "\n - ".join(DatabaseEngine.__members__.values())
-            )
-        )
-    if engine == DatabaseEngine.SQLite:
-        return get_sqlite(
-            folder=db_name, path=kwargs.pop("path"), new=kwargs.pop("new"), **kwargs
-        )
+class SQLiteConnectionState(pw._ConnectionState):
+    """Defaults to make SQLite DB async-compatible (according to FastAPI/Pydantic)"""
 
+    def __init__(self, **kwargs):
+        super().__setattr__("_state", db_state)
+        super().__init__(**kwargs)
+
+    def __setattr__(self, name, value):
+        self._state.get()[name] = value
+
+    def __getattr__(self, name):
+        return self._state.get()[name]
+
+
+def set_active_database(name: str) -> None:
+    """Sets the database as the currently active database"""
+    # Check if the name is already registered in .samudra/databases.toml
+    db_obj = read_database_info(name=name)
+    if db_obj is None:
+        raise FileNotFoundError(
+            f"The database name `{name}` is not found. Perhaps it is not created yet."
+        )
+    # Write the info in .samudra/config.toml
+    write_config({"active": name})
+    # TODO ? Write relevant variables into .env for server?
+
+
+def new_database(name: str, engine: DatabaseEngine, path: str) -> pw.Database:
+    """Create and register a SQLite database or just register a database if not SQLite"""
+    # ? Should this be a function parameters?
     DATABASE_HOST = os.getenv("DATABASE_HOST")
     DATABASE_PORT = int(os.getenv("DATABASE_PORT"))
     DATABASE_OPTIONS = os.getenv("DATABASE_OPTIONS")
     USERNAME = os.getenv("DATABASE_USERNAME")
     PASSWORD = os.getenv("DATABASE_PASSWORD")
     SSL_MODE = os.getenv("SSL_MODE")
-
+    if engine is None or engine not in DatabaseEngine.__members__.values():
+        raise ValueError(
+            "Invalid engine. You entered {}. Valid values are: \n - {}".format(
+                engine, "\n - ".join(DatabaseEngine.__members__.values())
+            )
+        )
+    if engine == DatabaseEngine.SQLite:
+        return create_sqlite(name=name, path=Path(path))
     if engine == DatabaseEngine.MySQL:
-        conn_str = f"mysql://{USERNAME}:{PASSWORD}@{DATABASE_HOST}:{DATABASE_PORT}/{db_name}?ssl-mode=REQUIRED"
+        conn_str = f"mysql://{USERNAME}:{PASSWORD}@{DATABASE_HOST}:{DATABASE_PORT}/{name}?ssl-mode=REQUIRED"
         return_db = pw.MySQLDatabase(conn_str)
-        logging.info(f"Connecting to {return_db.database} as {USERNAME}")
-    if engine == DatabaseEngine.CockroachDB:
-        from playhouse.cockroachdb import CockroachDatabase
-
-        conn_str = f"postgresql://{USERNAME}:{PASSWORD}@{DATABASE_HOST}:{DATABASE_PORT}/{db_name}?sslmode=verify-full&options={DATABASE_OPTIONS}"
-        return_db = CockroachDatabase(conn_str)
+        append_database_list(name=name, path=conn_str, engine=engine)
         logging.info(f"Connecting to {return_db.database} as {USERNAME}")
     else:
         raise NotImplementedError("Invalid engine")
-    return return_db
 
 
-def get_sqlite(folder: str, path: str, db_file: str = "samudra.db", new: bool = False):
-    # Defaults to make it async-compatible (according to FastAPI/Pydantic)
-    class PeeweeConnectionState(pw._ConnectionState):
-        def __init__(self, **kwargs):
-            super().__setattr__("_state", db_state)
-            super().__init__(**kwargs)
+def get_active_database() -> pw.Database:
+    active_database_name = read_config(key="active")
+    if not active_database_name:
+        raise KeyError("No active database is defined")
+    return get_database(name=active_database_name)
 
-        def __setattr__(self, name, value):
-            self._state.get()[name] = value
 
-        def __getattr__(self, name):
-            return self._state.get()[name]
+def get_database(name: str) -> pw.Database:
+    """Returns the connection class based on the name."""
+    info = read_database_info(name)
+    if info.get("engine") == DatabaseEngine.SQLite:
+        return_db = pw.SqliteDatabase(info.get("path"))
+        return_db._state = SQLiteConnectionState()
+        return return_db
+    if info.get("engine") == DatabaseEngine.MySQL:
+        return pw.MySQLDatabase(info.get("path"))
 
-    # The DB connection object
-    # ? Perlu ke test?
-    # TODO Add Test
-    base_path: Path = Path(path, folder)
-    full_path: Path = Path(base_path, db_file)
-    if new:
-        # If a new database is to be created, check if the given path is occupied.
-        # If not occupied, create the database.
-        # If occupied, raise FileExistsError
-        try:
-            base_path.mkdir(parents=True)
-        except FileExistsError:
-            if full_path in [*base_path.iterdir()]:
-                raise FileExistsError(
-                    f"A samudra database already exists in {full_path.resolve()}"
-                )
-            elif [*base_path.iterdir()] is [None]:
-                print(f"Populating empty folder `{base_path.resolve()}` with {db_file}")
-            else:
-                raise FileExistsError(
-                    f"The path `{base_path.resolve()}` is already occupied with something else. Try passing `new=False` to access the database or consider creating new database in another folder."
-                )
+
+def create_sqlite(
+    name: str, path: Path, filename: str = "samudra.db", description: str = ""
+) -> pw.SqliteDatabase:
+    base_path: Path = Path(path, name)
+    full_path: Path = Path(base_path, filename)
+    # Check if the given path is occupied.
+    # If not occupied, create the database.
+    # If occupied, raise FileExistsError.
+    try:
+        base_path.mkdir(parents=True)
+    except FileExistsError:
+        if full_path in [*base_path.iterdir()]:
+            raise FileExistsError(
+                f"A samudra database already exists in {full_path.resolve()}"
+            )
+        elif [*base_path.iterdir()] is [None]:
+            print(f"Populating empty folder `{base_path.resolve()}` with {filename}")
+        else:
+            raise FileExistsError(
+                f"The path `{base_path.resolve()}` is already occupied with something else. Consider creating new database in another folder."
+            )
         # Set up readme
         README = Path(base_path, "README.md")
         README.touch()
         with README.open(mode="w") as f:
             f.writelines(
                 [
-                    f"# {folder.title()}\n",
+                    f"# {name.title()}\n",
                     "Created using [samudra](https://github.com/samudradev/samudra)",
+                    "",
+                    description,
                 ]
             )
-    # else:
-    #     # Originally, this part was intended to get the path to database via its name in the local `~/.samudra/databases.toml` file when `new=False`.
-    #     # However, that would mean that the `path` parameter is rendered meaningless unless `new=True`.
-    #     # Perhaps this functionality should be outside the function with paths and folder parameters as its result
-    #     # which will be passed to `get_database/get_sqlite` with explicit `new=False`
-    #     db_obj = get_database_info(name=db_file)
-    #     if db_obj is None:
-    #         return FileNotFoundError(
-    #             f"The database name {db_file} is not found. Perhaps it is not created yet. Pass the key `new=True` if that's the case"
-    #         )
-    #     base_path: Path = Path(db_obj["path"], folder=db_file)
-    #     full_path: Path = Path(base_path, db_file)
     return_db = pw.SqliteDatabase(
         full_path.resolve(),
         check_same_thread=False,
     )
-    return_db._state = PeeweeConnectionState()
+    return_db._state = SQLiteConnectionState()
+    database_proxy.init(return_db)
+    database_proxy.create_tables()
     logging.info(f"Connecting to {return_db.database}")
+    append_database_list(name=name, path=full_path, engine="sqlite")
     return return_db

--- a/samudra/conf/database/options.py
+++ b/samudra/conf/database/options.py
@@ -4,4 +4,3 @@ import enum
 class DatabaseEngine(str, enum.Enum):
     SQLite = "sqlite"
     MySQL = "mysql"
-    CockroachDB = "cockroachdb"

--- a/samudra/conf/local.py
+++ b/samudra/conf/local.py
@@ -1,29 +1,46 @@
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Dict, Optional, Union, Any
 
 import pytomlpp as toml
 
 HOME: Path = Path("~")
 
 dotconfig = Path(HOME, ".samudra").expanduser()
-db_dotconfig = Path(dotconfig, "databases.toml")
+database_list_file = Path(dotconfig, "databases.toml")
+config_file = Path(dotconfig, "config.toml")
+
+database_list_file.touch()
+config_file.touch()
 
 if not dotconfig.exists():
     dotconfig.mkdir()
 
 
-def save_database(db_name: str, path: Path):
+def append_database_list(name: str, path: Union[Path, str], engine: str):
     databases: Dict[Dict] = defaultdict(dict)
-    databases[db_name] = path.resolve().__str__()
-    with open(db_dotconfig, mode="a") as f:
+    databases[name] = {"path": path.resolve().__str__(), "engine": engine}
+    with open(database_list_file, mode="a") as f:
         f.write(toml.dumps({"databases": databases}))
 
 
-def get_databases_config() -> dict:
-    with open(db_dotconfig, mode="r") as f:
-        return toml.load(f)
+def read_databases_list() -> dict:
+    return toml.load(database_list_file)
 
 
-def get_database_info(name: str) -> Optional[dict]:
-    return get_databases_config().get("databases").get(name, None)
+def read_database_info(name: str) -> Optional[dict]:
+    return read_databases_list().get("databases").get(name, None)
+
+
+def read_config(key: Optional[str] = None) -> Any:
+    configs = toml.load(config_file, mode="r")
+    if key:
+        return configs.get(key)
+    return configs
+
+
+def write_config(content: Dict) -> None:
+    configs = read_config(key=None)
+    for key, val in zip(content.keys(), content.values()):
+        configs[key] = val
+    toml.dump(configs, config_file, mode="w")

--- a/samudra/conf/setup.py
+++ b/samudra/conf/setup.py
@@ -1,5 +1,3 @@
-import os
-
 import peewee
 import pytomlpp as toml
 
@@ -11,6 +9,6 @@ settings = toml.load("conf.toml")
 
 def access_database(local: bool = True, name: str = None) -> peewee.Database:
     if local:
-        return get_database(db_name=name, engine=DatabaseEngine.SQLite, new=False)
+        return get_database(name=name, engine=DatabaseEngine.SQLite, new=False)
     else:
         raise NotImplementedError("Only loca database is implemented")

--- a/samudra/core/auth/pengguna.py
+++ b/samudra/core/auth/pengguna.py
@@ -1,11 +1,10 @@
 """Functions relating to the management of [`Pengguna`][samudra.models.auth.Pengguna]
 """
 
+from passlib.context import CryptContext
 from peewee import prefetch
 
 from samudra import models
-
-from passlib.context import CryptContext
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/samudra/core/crud/__init__.py
+++ b/samudra/core/crud/__init__.py
@@ -7,8 +7,8 @@
 - [golongan_kata][samudra.core.crud.golongan_kata]
 """
 
-from .lemma import *
-from .konsep import *
 from .cakupan import *
-from .kata_asing import *
 from .golongan_kata import *
+from .kata_asing import *
+from .konsep import *
+from .lemma import *

--- a/samudra/main.py
+++ b/samudra/main.py
@@ -1,5 +1,7 @@
 from typer import Typer
 
+from conf.database.core import get_active_database
+from models.base import database_proxy
 from samudra.cli import database, lemma, golongan_kata
 
 app = Typer()
@@ -10,4 +12,9 @@ app.add_typer(
 )
 
 if __name__ == "__main__":
+    try:
+        active = get_active_database()
+        database_proxy.initialize(active)
+    except KeyError:
+        pass
     app()

--- a/samudra/models/__init__.py
+++ b/samudra/models/__init__.py
@@ -19,14 +19,14 @@ from typing import List, Type
 
 import peewee
 
+from .auth.pengguna import Pengguna, Keizinan
 from .base import BaseDataTable
+from .core.cakupan import Cakupan, CakupanXKonsep
+from .core.kata_asing import KataAsing, KataAsingXKonsep
+from .core.konsep import Konsep, GolonganKata
 
 # Ordered by table hierarchy
 from .core.lemma import Lemma
-from .core.konsep import Konsep, GolonganKata
-from .core.cakupan import Cakupan, CakupanXKonsep
-from .core.kata_asing import KataAsing, KataAsingXKonsep
-from .auth.pengguna import Pengguna, Keizinan
 from .experimental.petikan import Petikan, PetikanXKonsep, SumberPetikan
 
 
@@ -52,6 +52,8 @@ def create_tables(
     return database.get_tables()
 
 
+# Binding to database at runtime is time-consuming
+# TODO ? REMOVE this in favor of db proxy init
 def bind_to_database(
     database: peewee.Database, auth: bool = True, experimental: bool = False
 ):

--- a/samudra/models/base.py
+++ b/samudra/models/base.py
@@ -10,8 +10,10 @@ The four bases currently available:
 from collections import defaultdict
 from typing import List, Dict, Tuple, Type
 
-import peewee
 import peewee as pw
+
+# TODO ! Initialize database at runtime using this proxy
+database_proxy = pw.DatabaseProxy()
 
 
 class BaseDataTable(pw.Model):
@@ -37,6 +39,7 @@ class BaseDataTable(pw.Model):
 
     class Meta:
         legacy_table_names = False
+        database = database_proxy
 
 
 class BaseRelationshipTable(BaseDataTable):

--- a/samudra/models/core/cakupan.py
+++ b/samudra/models/core/cakupan.py
@@ -1,7 +1,7 @@
-from peewee import BlobField, TextField, ForeignKeyField
+from peewee import TextField, ForeignKeyField
 
-from ..base import BaseDataTable, BaseAttachmentDataTable, BaseRelationshipTable
 from .konsep import Konsep
+from ..base import BaseAttachmentDataTable, BaseRelationshipTable
 
 
 class Cakupan(BaseAttachmentDataTable):

--- a/samudra/models/core/kata_asing.py
+++ b/samudra/models/core/kata_asing.py
@@ -1,7 +1,7 @@
 from peewee import ForeignKeyField, TextField
 
-from ..base import BaseAttachmentDataTable, BaseRelationshipTable
 from .konsep import Konsep
+from ..base import BaseAttachmentDataTable, BaseRelationshipTable
 
 
 class KataAsing(BaseAttachmentDataTable):

--- a/samudra/models/core/konsep.py
+++ b/samudra/models/core/konsep.py
@@ -1,23 +1,19 @@
 from typing import Dict, List
 
 from peewee import (
-    AutoField,
     TextField,
     IntegerField,
-    TimestampField,
-    BlobField,
     ForeignKeyField,
     ModelSelect,
     CharField,
 )
 
+from .lemma import Lemma
 from ..base import (
     BaseDataTable,
     BaseAttachmentDataTable,
-    BaseRelationshipTable,
     BaseStrictDataTable,
 )
-from .lemma import Lemma
 
 
 class GolonganKata(BaseStrictDataTable):

--- a/samudra/schemas/__init__.py
+++ b/samudra/schemas/__init__.py
@@ -6,15 +6,13 @@
     As such, I put off documenting it now as I prioritize other docs.
 """
 
-# Ordered by table hierarchy
-from samudra.schemas.tables.lemma import LemmaResponse
+from samudra.schemas.input.annotated_text import AnnotatedText
+from samudra.schemas.tables.golongan_kata import CreateGolonganKata
 from samudra.schemas.tables.konsep import (
     KonsepResponseFromTables,
     KonsepResponseFromAnnotatedBody,
 )
 
-from samudra.schemas.input.annotated_text import AnnotatedText
-
+# Ordered by table hierarchy
+from samudra.schemas.tables.lemma import LemmaResponse
 from samudra.schemas.tables.user import LogMasukResponse, DaftarResponse
-
-from samudra.schemas.tables.golongan_kata import CreateGolonganKata

--- a/samudra/schemas/tables/cakupan.py
+++ b/samudra/schemas/tables/cakupan.py
@@ -1,9 +1,6 @@
 from typing import Optional
 
-import pydantic as pyd
-
-from samudra import models
-from samudra.schemas.tables._helper import PeeweeGetterDict, ORMSchema
+from samudra.schemas.tables._helper import ORMSchema
 
 
 class CakupanResponse(ORMSchema):

--- a/samudra/schemas/tables/konsep.py
+++ b/samudra/schemas/tables/konsep.py
@@ -1,9 +1,6 @@
 from typing import Optional, List
 
-import pydantic as pyd
-
-from samudra import models
-from samudra.schemas.tables._helper import PeeweeGetterDict, ORMSchema
+from samudra.schemas.tables._helper import ORMSchema
 from samudra.schemas.tables.cakupan import AttachCakupanToResponse, CakupanResponse
 from samudra.schemas.tables.kata_asing import (
     AttachKataAsingToResponse,

--- a/samudra/schemas/tables/lemma.py
+++ b/samudra/schemas/tables/lemma.py
@@ -1,8 +1,6 @@
 from typing import List
 
-import pydantic as pyd
-
-from samudra.schemas.tables._helper import PeeweeGetterDict, ORMSchema
+from samudra.schemas.tables._helper import ORMSchema
 from samudra.schemas.tables.konsep import KonsepResponseFromTables
 
 

--- a/samudra/schemas/tables/user.py
+++ b/samudra/schemas/tables/user.py
@@ -1,9 +1,6 @@
-from typing import List
-
 import pydantic as pyd
 
-from samudra.schemas.tables._helper import PeeweeGetterDict, ORMSchema
-from samudra.schemas.tables.konsep import KonsepResponseFromTables
+from samudra.schemas.tables._helper import ORMSchema
 
 
 class Token(pyd.BaseModel):

--- a/samudra/serve.py
+++ b/samudra/serve.py
@@ -37,7 +37,7 @@ def root() -> Dict[str, str]:
 
 if __name__ == "__main__":
     # TODO Bind to database
-    uvicorn.run("serve:app", port=8000, reload=True)
+    uvicorn.run("serve:app", port=8000, reload=False)
 
 # TODO: CLI
 # TODO: Share lemma via picture

--- a/samudra/serve.py
+++ b/samudra/serve.py
@@ -4,7 +4,6 @@
 from typing import Dict
 
 import uvicorn
-
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -15,7 +14,6 @@ SLEEP_TIME: int = 10
 
 app = FastAPI()
 
-# TODO: Add more server endpoints!
 app.include_router(lemmas.router)
 app.include_router(auth.router)
 app.include_router(golongan_kata.router)
@@ -36,7 +34,6 @@ def root() -> Dict[str, str]:
 
 
 if __name__ == "__main__":
-    # TODO Bind to database
     uvicorn.run("serve:app", port=8000, reload=False)
 
 # TODO: CLI

--- a/samudra/server/dependencies.py
+++ b/samudra/server/dependencies.py
@@ -1,8 +1,8 @@
 from fastapi import Depends
 from fastapi.security import OAuth2PasswordBearer
 
-from samudra.server.setup import SERVER_DATABASE
 from samudra.conf.database.core import db_state_default
+from samudra.server.setup import SERVER_DATABASE
 
 
 async def reset_db_state() -> None:

--- a/samudra/server/routes/auth.py
+++ b/samudra/server/routes/auth.py
@@ -1,11 +1,11 @@
+from datetime import timedelta
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from samudra import models, schemas
 from samudra.core import auth
 from samudra.server.dependencies import get_db
-from datetime import timedelta
-
 from samudra.server.tokens import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
     PenggunaCreateDTO,

--- a/samudra/server/routes/golongan_kata.py
+++ b/samudra/server/routes/golongan_kata.py
@@ -1,7 +1,8 @@
 from typing import Union
-from fastapi import APIRouter, Depends, HTTPException
-from samudra import models
 
+from fastapi import APIRouter, Depends, HTTPException
+
+from samudra import models
 from samudra import schemas
 from samudra.core import crud
 from samudra.server.dependencies import get_db, oauth2_scheme

--- a/samudra/server/routes/lemmas.py
+++ b/samudra/server/routes/lemmas.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from samudra import models, schemas
 from samudra.core import crud
-from samudra.server.dependencies import get_db
 from samudra.schemas.input.query_filter import QueryFilter
+from samudra.server.dependencies import get_db
 from samudra.server.dependencies import oauth2_scheme
 
 router = APIRouter(prefix="/lemma", dependencies=[Depends(get_db)])

--- a/samudra/server/setup.py
+++ b/samudra/server/setup.py
@@ -10,7 +10,11 @@ from conf.setup import settings
 # TODO Remove ENGINE config
 ENGINE = settings.get("database").get("engine", None)
 DATABASE_NAME = settings.get("database").get("name", "samudra")
-PATH = ''
+PATH = ""
 
-SERVER_DATABASE: pw.Database = get_database(engine=DatabaseEngine[ENGINE], db_name=DATABASE_NAME, path=PATH, new=True)
+# We should find a way to only pass `new=True` upon first initialization of the server
+# But pass `new=False` when restarting the server OR when database already exists
+SERVER_DATABASE: pw.Database = get_database(
+    engine=DatabaseEngine[ENGINE], db_name=DATABASE_NAME, path=PATH, new=False
+)
 create_tables(database=SERVER_DATABASE)

--- a/samudra/server/setup.py
+++ b/samudra/server/setup.py
@@ -1,11 +1,9 @@
-import logging
-
 import peewee as pw
 
-from samudra.models import create_tables
+from conf.setup import settings
 from samudra.conf import get_database
 from samudra.conf.database.options import DatabaseEngine
-from conf.setup import settings
+from samudra.models import create_tables
 
 # TODO Remove ENGINE config
 ENGINE = settings.get("database").get("engine", None)
@@ -15,6 +13,6 @@ PATH = ""
 # We should find a way to only pass `new=True` upon first initialization of the server
 # But pass `new=False` when restarting the server OR when database already exists
 SERVER_DATABASE: pw.Database = get_database(
-    engine=DatabaseEngine[ENGINE], db_name=DATABASE_NAME, path=PATH, new=False
+    engine=DatabaseEngine[ENGINE], name=DATABASE_NAME, path=PATH, new=False
 )
 create_tables(database=SERVER_DATABASE)

--- a/samudra/server/setup.py
+++ b/samudra/server/setup.py
@@ -1,1 +1,16 @@
+import logging
 
+import peewee as pw
+
+from samudra.models import create_tables
+from samudra.conf import get_database
+from samudra.conf.database.options import DatabaseEngine
+from conf.setup import settings
+
+# TODO Remove ENGINE config
+ENGINE = settings.get("database").get("engine", None)
+DATABASE_NAME = settings.get("database").get("name", "samudra")
+PATH = ''
+
+SERVER_DATABASE: pw.Database = get_database(engine=DatabaseEngine[ENGINE], db_name=DATABASE_NAME, path=PATH, new=True)
+create_tables(database=SERVER_DATABASE)


### PR DESCRIPTION
## Isu yang dituju
#20 #21 

## Perubahan yang dibuat
- Mengikat (`bind`) model dan pengkalan data melalui fungsi `create_tables` daripada `samudra.models`.

## Perincian perubahan lain
- Mengalihkan pemalar global `ENGINE`, `DATABASE_NAME` ke `samudra/server/setup.py` untuk mengelakkan nilai ini dirujuk sebelum pentakrifan semasa proses permulaan. 
- Meletakkan pemalar global `PATH` di dalam `samudra/server/setup.py` untuk menjelaskan keperluan argumen `path` dalam panggilan `get_database` di `samudra/server/setup.py`.
- Menukarkan argumen `reload` kepada `False` untuk panggilan kaedah `uvicorn.run()` untuk mengelakkan proses pemulaan, penciptaan, dan pengikatan pengkalan data diulangi ketika pelayan sedang berjalan.


Kalau boleh, minta tolong @Thaza-Kun tolong semak sama ada perubahan ini masuk akal ataupun ada perkara yang boleh dibuat dengan lebih molek.